### PR TITLE
Add i18n 3rd party lib support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ owasp.config({
   minLength              : 10,
   minPhraseLength        : 20,
   minOptionalTestsToPass : 4,
+  i18nErrorKeys          : false,
 });
 ```
 
@@ -184,6 +185,12 @@ Whereby:
   OWASP guidelines), four optional complexity tests are made, and a password
   must pass at least three of them in order to be considered "strong". 
 
+- `i18nErrorKeys` is a `boolean` that toggles the i18n error keys in place of
+  english error messages. This can be useful when translating the errors using
+  a 3rd party i18n library. When true the following keys can be returned:
+  `failedMinLength`, `failedMaxLength`, `failedThreeRepeatedChars`,
+  `optionalLowercaseRequired`, `optionalUppercaseRequired`,
+  `optionalNumberRequired` and `optionalSpecialCharRequired`.
 
 Extending
 ---------

--- a/owasp-password-strength-test.js
+++ b/owasp-password-strength-test.js
@@ -21,6 +21,7 @@
       minLength              : 10,
       minPhraseLength        : 20,
       minOptionalTestsToPass : 4,
+      i18nErrorKeys          : false,
     };
 
     // This method makes it more convenient to set config parameters
@@ -42,21 +43,27 @@
         // enforce a minimum length
         function(password) {
           if (password.length < owasp.configs.minLength) {
-            return 'The password must be at least ' + owasp.configs.minLength + ' characters long.';
+            return owasp.configs.i18nErrorKeys
+              ? 'failedMinLength'
+              : 'The password must be at least ' + owasp.configs.minLength + ' characters long.';
           }
         },
 
         // enforce a maximum length
         function(password) {
           if (password.length > owasp.configs.maxLength) {
-            return 'The password must be fewer than ' + owasp.configs.maxLength + ' characters.';
+            return owasp.configs.i18nErrorKeys
+              ? 'failedMaxLength'
+              : 'The password must be fewer than ' + owasp.configs.maxLength + ' characters.';
           }
         },
 
         // forbid repeating characters
         function(password) {
           if (/(.)\1{2,}/.test(password)) {
-            return 'The password may not contain sequences of three or more repeated characters.';
+            return owasp.configs.i18nErrorKeys
+              ? 'failedThreeRepeatedChars'
+              : 'The password may not contain sequences of three or more repeated characters.';
           }
         },
 
@@ -76,28 +83,36 @@
         // require at least one lowercase letter
         function(password) {
           if (!/[a-z]/.test(password)) {
-            return 'The password must contain at least one lowercase letter.';
+            return owasp.configs.i18nErrorKeys
+              ? 'optionalLowercaseRequired'
+              : 'The password must contain at least one lowercase letter.';
           }
         },
 
         // require at least one uppercase letter
         function(password) {
           if (!/[A-Z]/.test(password)) {
-            return 'The password must contain at least one uppercase letter.';
+            return owasp.configs.i18nErrorKeys
+              ? 'optionalUppercaseRequired'
+              : 'The password must contain at least one uppercase letter.';
           }
         },
 
         // require at least one number
         function(password) {
           if (!/[0-9]/.test(password)) {
-            return 'The password must contain at least one number.';
+            return owasp.configs.i18nErrorKeys
+              ? 'optionalNumberRequired'
+              : 'The password must contain at least one number.';
           }
         },
 
         // require at least one special character
         function(password) {
           if (!/[^A-Za-z0-9]/.test(password)) {
-            return 'The password must contain at least one special character.';
+            return owasp.configs.i18nErrorKeys
+              ? 'optionalSpecialCharRequired'
+              : 'The password must contain at least one special character.';
           }
         },
 

--- a/test.js
+++ b/test.js
@@ -124,17 +124,40 @@ describe('configs', function() {
       minLength              : 5,
       minPhraseLength        : 5,
       minOptionalTestsToPass : 5,
+      i18nErrorKeys          : true,
     });
     owasp.configs.allowPassphrases.should.be.false;
     owasp.configs.maxLength.should.be.exactly(5);
     owasp.configs.minLength.should.be.exactly(5);
     owasp.configs.minPhraseLength.should.be.exactly(5);
     owasp.configs.minOptionalTestsToPass.should.be.exactly(5);
+    owasp.configs.i18nErrorKeys.should.be.true;
   });
 
   it('should reject invalid parameter keys', function() {
     owasp.config({ foo: 'bar' });
     owasp.configs.should.not.have.property('foo');
+  });
+
+});
+
+describe('i18n', function() {
+
+  it('should return i18 error keys', function() {
+    owasp.config({
+      allowPassphrases       : true,
+      maxLength              : 50,
+      minLength              : 10,
+      minPhraseLength        : 20,
+      minOptionalTestsToPass : 3,
+      i18nErrorKeys          : true,
+    });
+    var result = owasp.test('L0eSex');
+    result.errors.should.have.length(2);
+    result.requiredTestErrors.should.have.length(1);
+    result.requiredTestErrors[0].should.be.exactly('failedMinLength');
+    owasp.configs.minLength.should.be.exactly(10);
+    result.optionalTestErrors[0].should.be.exactly('optionalSpecialCharRequired');
   });
 
 });


### PR DESCRIPTION
Instead of guessing the error numbers (which are [not guaranteed](http://stackoverflow.com/questions/5525795/does-javascript-guarantee-object-property-order) to be constant between different js interpreters), this change allows a `{ i18nErrorKeys: true }` config option to be supplied which then replaces the English error messages with keys that can be used together with 3rd party i18n translation libraries.

The default behaviour remains unchanged and should not affect existing implementations.
