### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export as namespace owaspPasswordStrengthTest;
-export = owaspPasswordStrengthTest;
+export default owaspPasswordStrengthTest;
 
 interface PasswordTestResult {
     /** error messages associated with the failed tests */
@@ -39,7 +39,7 @@ interface PasswordTestConfiguration {
     i18nErrorKeys?: boolean;
 }
 
-type PasswordTest = (password: string) => boolean;
+type PasswordTest = (password: string) => string | undefined;
 
 declare namespace owaspPasswordStrengthTest {
     export function test(password: string): PasswordTestResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,13 @@ interface PasswordTestConfiguration {
     minPhraseLength?: number;
     /** minimum number of optional tests that a password must pass in order to be considered "strong". By default (per the OWASP guidelines), four optional complexity tests are made, and a password must pass at least three of them in order to be considered "strong" */
     minOptionalTestsToPass?: number;
+    /**
+     * toggles the i18n error keys in place of english error messages.
+     * This can be useful when translating the errors using a 3rd party i18n library.
+     * When true the following keys can be returned:
+     * `failedMinLength`, `failedMaxLength`, `failedThreeRepeatedChars`, `optionalLowercaseRequired`, `optionalUppercaseRequired`, `optionalNumberRequired` and `optionalSpecialCharRequired`.
+     */
+    i18nErrorKeys?: boolean;
 }
 
 type PasswordTest = (password: string) => boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
-export default owaspPasswordStrengthTest;
+export as namespace owaspPasswordStrengthTest;
+export = owaspPasswordStrengthTest;
 
 interface PasswordTestResult {
     /** error messages associated with the failed tests */
@@ -33,7 +34,7 @@ interface PasswordTestConfiguration {
 
 type PasswordTest = (password: string) => boolean;
 
-export declare namespace owaspPasswordStrengthTest {
+declare namespace owaspPasswordStrengthTest {
     export function test(password: string): PasswordTestResult;
     export function config(configuration: PasswordTestConfiguration): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,6 @@
 export as namespace owaspPasswordStrengthTest;
-export = owaspPasswordStrengthTest;
 
-interface PasswordTestResult {
+export interface PasswordTestResult {
     /** error messages associated with the failed tests */
     errors: string[];
     /** enumerates which tests have failed, beginning from 0 with the first required test */
@@ -16,37 +15,53 @@ interface PasswordTestResult {
     isPassphrase: boolean;
     /** indicates whether or not the user's password satisfied the strength requirements */
     strong: boolean;
-    /**  indicates how many of the optional tests were passed. In order for the password to be considered "strong", it (by default) must either be a passphrase, or must pass a number of optional tests that is equal to or greater than configs.minOptionalTestsToPass */
+    /**
+     * indicates how many of the optional tests were passed;
+     * In order for the password to be considered "strong", it (by default) must either be a passphrase,
+     * or must pass a number of optional tests that is equal to or greater than configs.minOptionalTestsToPass
+     */
     optionalTestsPassed: number;
 }
-interface PasswordTestConfiguration {
-    /** Toggles the "passphrase" mechanism on and off. If set to false, the strength-checker will abandon the notion of "passphrases", and will subject all passwords to the same complexity requirements. */
+export interface PasswordTestConfiguration {
+    /**
+     * toggles the "passphrase" mechanism on and off;
+     * If set to false, the strength-checker will abandon the notion of "passphrases",
+     * and will subject all passwords to the same complexity requirements.
+     */
     allowPassphrases?: boolean;
     /** constraint on a password's maximum length */
     maxLength?: number;
     /** constraint on a password's minimum length */
     minLength?: number;
-    /** minimum length a password needs to achieve in order to be considered a "passphrase" (and thus exempted from the optional complexity tests by default) */
-    minPhraseLength?: number;
-    /** minimum number of optional tests that a password must pass in order to be considered "strong". By default (per the OWASP guidelines), four optional complexity tests are made, and a password must pass at least three of them in order to be considered "strong" */
-    minOptionalTestsToPass?: number;
     /**
-     * toggles the i18n error keys in place of english error messages.
-     * This can be useful when translating the errors using a 3rd party i18n library.
-     * When true the following keys can be returned:
-     * `failedMinLength`, `failedMaxLength`, `failedThreeRepeatedChars`, `optionalLowercaseRequired`, `optionalUppercaseRequired`, `optionalNumberRequired` and `optionalSpecialCharRequired`.
+     * minimum length a password needs to achieve in order to be considered a "passphrase"
+     * (and thus exempted from the optional complexity tests by default)
      */
-    i18nErrorKeys?: boolean;
+    minPhraseLength?: number;
+    /**
+     * minimum number of optional tests that a password must pass in order to be considered "strong";
+     * By default (per the OWASP guidelines), four optional complexity tests are made,
+     * and a password must pass at least three of them in order to be considered "strong"
+     */
+    minOptionalTestsToPass?: number;
+
+    // // to add support for https://github.com/nowsecure/owasp-password-strength-test/pull/5
+    // /**
+    //  * toggles the i18n error keys in place of english error messages.
+    //  * This can be useful when translating the errors using a 3rd party i18n library.
+    //  * When true the following keys can be returned:
+    //  * `failedMinLength`, `failedMaxLength`, `failedThreeRepeatedChars`, `optionalLowercaseRequired`, `optionalUppercaseRequired`, `optionalNumberRequired` and `optionalSpecialCharRequired`.
+    //  */
+    // i18nErrorKeys?: boolean;
 }
 
-type PasswordTest = (password: string) => string | undefined;
+export type PasswordTest = (password: string) => string | undefined;
 
-declare namespace owaspPasswordStrengthTest {
-    export function test(password: string): PasswordTestResult;
-    export function config(configuration: PasswordTestConfiguration): void;
+export function test(password: string): PasswordTestResult;
+export function config(configuration: PasswordTestConfiguration): void;
 
-    export let tests: {
-        required: PasswordTest[];
-        optional: PasswordTest[];
-    };
-}
+export let tests: {
+    required: PasswordTest[];
+    optional: PasswordTest[];
+};
+export const configs: Readonly<PasswordTestConfiguration>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export as namespace owaspPasswordStrengthTest;
-export default owaspPasswordStrengthTest;
+export = owaspPasswordStrengthTest;
 
 interface PasswordTestResult {
     /** error messages associated with the failed tests */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,44 @@
+export default owaspPasswordStrengthTest;
+
+interface PasswordTestResult {
+    /** error messages associated with the failed tests */
+    errors: string[];
+    /** enumerates which tests have failed, beginning from 0 with the first required test */
+    failedTests: number[];
+    /** enumerates which tests have succeeded, beginning from 0 with the first required test */
+    passedTests: number[];
+    /** error messages of required tests that have failed */
+    requiredTestErrors: string[];
+    /** error messages of optional tests that have failed */
+    optionalTestErrors: string[];
+    /** indicates whether or not the password was considered to be a passphrase */
+    isPassphrase: boolean;
+    /** indicates whether or not the user's password satisfied the strength requirements */
+    strong: boolean;
+    /**  indicates how many of the optional tests were passed. In order for the password to be considered "strong", it (by default) must either be a passphrase, or must pass a number of optional tests that is equal to or greater than configs.minOptionalTestsToPass */
+    optionalTestsPassed: number;
+}
+interface PasswordTestConfiguration {
+    /** Toggles the "passphrase" mechanism on and off. If set to false, the strength-checker will abandon the notion of "passphrases", and will subject all passwords to the same complexity requirements. */
+    allowPassphrases?: boolean;
+    /** constraint on a password's maximum length */
+    maxLength?: number;
+    /** constraint on a password's minimum length */
+    minLength?: number;
+    /** minimum length a password needs to achieve in order to be considered a "passphrase" (and thus exempted from the optional complexity tests by default) */
+    minPhraseLength?: number;
+    /** minimum number of optional tests that a password must pass in order to be considered "strong". By default (per the OWASP guidelines), four optional complexity tests are made, and a password must pass at least three of them in order to be considered "strong" */
+    minOptionalTestsToPass?: number;
+}
+
+type PasswordTest = (password: string) => boolean;
+
+export declare namespace owaspPasswordStrengthTest {
+    export function test(password: string): PasswordTestResult;
+    export function config(configuration: PasswordTestConfiguration): void;
+
+    export let tests: {
+        required: PasswordTest[];
+        optional: PasswordTest[];
+    };
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 export as namespace owaspPasswordStrengthTest;
 
-export interface PasswordTestResult {
+export interface TestResult {
     /** error messages associated with the failed tests */
     errors: string[];
     /** enumerates which tests have failed, beginning from 0 with the first required test */
@@ -22,28 +22,28 @@ export interface PasswordTestResult {
      */
     optionalTestsPassed: number;
 }
-export interface PasswordTestConfiguration {
+export interface TestConfig {
     /**
      * toggles the "passphrase" mechanism on and off;
      * If set to false, the strength-checker will abandon the notion of "passphrases",
      * and will subject all passwords to the same complexity requirements.
      */
-    allowPassphrases?: boolean;
+    allowPassphrases: boolean;
     /** constraint on a password's maximum length */
-    maxLength?: number;
+    maxLength: number;
     /** constraint on a password's minimum length */
-    minLength?: number;
+    minLength: number;
     /**
      * minimum length a password needs to achieve in order to be considered a "passphrase"
      * (and thus exempted from the optional complexity tests by default)
      */
-    minPhraseLength?: number;
+    minPhraseLength: number;
     /**
      * minimum number of optional tests that a password must pass in order to be considered "strong";
      * By default (per the OWASP guidelines), four optional complexity tests are made,
      * and a password must pass at least three of them in order to be considered "strong"
      */
-    minOptionalTestsToPass?: number;
+    minOptionalTestsToPass: number;
 
     // // to add support for https://github.com/nowsecure/owasp-password-strength-test/pull/5
     // /**
@@ -57,11 +57,11 @@ export interface PasswordTestConfiguration {
 
 export type PasswordTest = (password: string) => string | undefined;
 
-export function test(password: string): PasswordTestResult;
-export function config(configuration: PasswordTestConfiguration): void;
+export function test(password: string): TestResult;
+export function config(configuration: Partial<TestConfig>): void;
 
 export let tests: {
     required: PasswordTest[];
     optional: PasswordTest[];
 };
-export const configs: Readonly<PasswordTestConfiguration>;
+export const configs: Readonly<TestConfig>;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "A password-strength tester based upon the OWASP guidelines for enforcing strong passwords.",
   "main": "owasp-password-strength-test.js",
+  "typings": "./index.d.ts",
   "devDependencies": {
     "jshint": "2.6.3",
     "mocha": "2.2.4",


### PR DESCRIPTION
That should fix #14 .
Usage within TypeScript:
```TypeScript
import * as owasp from 'owasp-password-strength-test';
owasp. ...
```
or using UMD: ```owaspPasswordStrengthTest. ...```